### PR TITLE
The commit "regulatory: add NUL to request alpha2" increases the leng…

### DIFF
--- a/patches/bcm43430a1/7_45_41_46/nexmon/brcmfmac_4.14.y-nexmon/cfg80211.c
+++ b/patches/bcm43430a1/7_45_41_46/nexmon/brcmfmac_4.14.y-nexmon/cfg80211.c
@@ -7062,7 +7062,7 @@ static void brcmf_cfg80211_reg_notifier(struct wiphy *wiphy,
 		return;
 
 	/* ignore non-ISO3166 country codes */
-	for (i = 0; i < sizeof(req->alpha2); i++)
+	for (i = 0; i < 2; i++)
 		if (req->alpha2[i] < 'A' || req->alpha2[i] > 'Z') {
 			if (req->alpha2[0] == '0' && req->alpha2[1] == '0')
 				return;


### PR DESCRIPTION
…th of

alpha2 to 3. This causes a regression on brcmfmac, because
brcmf_cfg80211_reg_notifier() expect valid ISO3166 codes in the complete
array. So fix this accordingly.

@see https://patchwork.kernel.org/patch/10283389

Signed-off-by: Stefan Wahren <stefan.wahren@i2se.com>
Signed-off-by: Alex J Lennon <alex@spriteguard.com>